### PR TITLE
Update Imaginer runtime to 46

### DIFF
--- a/page.codeberg.Imaginer.Imaginer.json
+++ b/page.codeberg.Imaginer.Imaginer.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "page.codeberg.Imaginer.Imaginer",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "imaginer",
     "finish-args" : [


### PR DESCRIPTION
- Update Imaginer runtime to 46 since runtime version 44 has reached end-of-life.